### PR TITLE
feat: Adding toggle

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -82,6 +82,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Key::Right => {
                     app.tree.open();
                 }
+                Key::Char('\n') => {
+                    app.tree.toggle();
+                }
                 Key::Down => {
                     app.tree.next();
                 }

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -60,4 +60,8 @@ impl<'a> StatefulTree<'a> {
     pub fn open(&mut self) {
         self.state.open(self.state.selected());
     }
+
+    pub fn toggle(&mut self) {
+        self.state.toggle();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,11 +60,11 @@ impl TreeState {
 
     /// Toggles a tree node.
     /// If the node is in opened then it calls `close()`. Otherwise it calls `open()`.
-    pub fn toggle(&mut self) -> bool {
+    pub fn toggle(&mut self) {
         if self.opened.contains(&self.selected()) {
-            self.close(&self.selected())
+            self.close(&self.selected());
         } else {
-            self.open(self.selected())
+            self.open(self.selected());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,16 @@ impl TreeState {
         self.opened.remove(identifier)
     }
 
+    /// Toggles a tree node.
+    /// If the node is in opened then it calls `close()`. Otherwise it calls `open()`.
+    pub fn toggle(&mut self) -> bool {
+        if self.opened.contains(&self.selected()) {
+            self.close(&self.selected())
+        } else {
+            self.open(self.selected())
+        }
+    }
+
     pub fn close_all(&mut self) {
         self.opened.clear();
     }


### PR DESCRIPTION
This PR creates a `toggle` method for TreeState which allows for one key press to either open or close the tree. 