### PR TITLE
feat: configure node open state symbols

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,11 +273,11 @@ pub struct Tree<'a> {
     highlight_symbol: Option<&'a str>,
 
     /// Symbol displayed in front of a closed node (As in the children are currently not visible)
-    node_closed_symbol: Option<&'a str>,
+    node_closed_symbol: &'a str,
     /// Symbol displayed in front of an open node. (As in the children are currently visible)
-    node_open_symbol: Option<&'a str>,
+    node_open_symbol: &'a str,
     /// Symbol displayed in front of a node without children.
-    node_no_children_symbol: Option<&'a str>,
+    node_no_children_symbol: &'a str,
 }
 
 impl<'a> Tree<'a> {
@@ -292,9 +292,9 @@ impl<'a> Tree<'a> {
             start_corner: Corner::TopLeft,
             highlight_style: Style::default(),
             highlight_symbol: None,
-            node_open_symbol: Some("\u{25bc} "),   // Arrow down
-            node_closed_symbol: Some("\u{25b6} "), // Arrow to right
-            node_no_children_symbol: Some("  "),
+            node_open_symbol: "\u{25bc} ",   // Arrow down
+            node_closed_symbol: "\u{25b6} ", // Arrow to right
+            node_no_children_symbol: "  ",
         }
     }
 
@@ -443,8 +443,7 @@ impl<'a> StatefulWidget for Tree<'a> {
                     self.node_open_symbol
                 } else {
                     self.node_closed_symbol
-                }
-                .unwrap_or("");
+                };
                 let max_width = area.width.saturating_sub(after_indent_x - x);
                 let (x, _) =
                     buf.set_stringn(after_indent_x, y, symbol, max_width as usize, item_style);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,24 @@ impl<'a> Tree<'a> {
         self.highlight_symbol = Some(highlight_symbol);
         self
     }
+
+    #[must_use]
+    pub const fn node_closed_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_closed_symbol = symbol;
+        self
+    }
+
+    #[must_use]
+    pub const fn node_open_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_open_symbol = symbol;
+        self
+    }
+
+    #[must_use]
+    pub const fn node_no_children_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_no_children_symbol = symbol;
+        self
+    }
 }
 
 impl<'a> StatefulWidget for Tree<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,11 +262,13 @@ impl<'a> TreeItem<'a> {
 /// ```
 #[derive(Debug, Clone)]
 pub struct Tree<'a> {
-    block: Option<Block<'a>>,
     items: Vec<TreeItem<'a>>,
+
+    block: Option<Block<'a>>,
+    start_corner: Corner,
     /// Style used as a base style for the widget
     style: Style,
-    start_corner: Corner,
+
     /// Style used to render selected item
     highlight_style: Style,
     /// Symbol in front of the selected item (Shift all items to the right)
@@ -286,14 +288,14 @@ impl<'a> Tree<'a> {
         T: Into<Vec<TreeItem<'a>>>,
     {
         Self {
-            block: None,
-            style: Style::default(),
             items: items.into(),
+            block: None,
             start_corner: Corner::TopLeft,
+            style: Style::default(),
             highlight_style: Style::default(),
             highlight_symbol: None,
-            node_open_symbol: "\u{25bc} ",   // Arrow down
             node_closed_symbol: "\u{25b6} ", // Arrow to right
+            node_open_symbol: "\u{25bc} ",   // Arrow down
             node_no_children_symbol: "  ",
         }
     }
@@ -306,14 +308,14 @@ impl<'a> Tree<'a> {
     }
 
     #[must_use]
-    pub const fn style(mut self, style: Style) -> Self {
-        self.style = style;
+    pub const fn start_corner(mut self, corner: Corner) -> Self {
+        self.start_corner = corner;
         self
     }
 
     #[must_use]
-    pub const fn highlight_symbol(mut self, highlight_symbol: &'a str) -> Self {
-        self.highlight_symbol = Some(highlight_symbol);
+    pub const fn style(mut self, style: Style) -> Self {
+        self.style = style;
         self
     }
 
@@ -324,8 +326,8 @@ impl<'a> Tree<'a> {
     }
 
     #[must_use]
-    pub const fn start_corner(mut self, corner: Corner) -> Self {
-        self.start_corner = corner;
+    pub const fn highlight_symbol(mut self, highlight_symbol: &'a str) -> Self {
+        self.highlight_symbol = Some(highlight_symbol);
         self
     }
 }


### PR DESCRIPTION
This is a base implementation for configuration of symbols which works but isn't finished yet.

closes #17

The current state raises some questions:

- What happens on different width symbols? Should that be handled in some way?
- How to do the methods setting these? The default is already `Some(…)` and the other methods default to None so overriding and setting it will always be something afterwards. Change the other methods to accept `Option<&str>` too?