### PR TITLE
feat: Add multiline tree that can be layouted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ include = ["src/**/*", "README.md"]
 [dependencies]
 tui = { version = "0.19", default-features = false }
 unicode-width = "0.1"
+textwrap = { version = "0.16.0" }
 
 [dev-dependencies]
 crossterm = "0.25"

--- a/examples/multiline.rs
+++ b/examples/multiline.rs
@@ -1,0 +1,151 @@
+mod util;
+
+use crate::util::StatefulTree;
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use std::{error::Error, io, time::SystemTime};
+use tui::{
+    backend::{Backend, CrosstermBackend},
+    layout::Constraint,
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders},
+    Terminal,
+};
+
+use tui_tree_widget::{MultilineTree, TreeItem};
+
+const P_G: &str = "Peer selection when creating outbound connections should be based on a *similarity index* based on how many tracked projects are shared/in common.
+
+Once #25 is done, the next iteration is to be smart about who we connect to. To compute the similarity index between our node and a peer, we can compare our bloom filter with a peer's bloom filter, using the built-in similarity metrics of the bloom filter implementation.
+
+We then rank all peers by similarity, and connect to the closest peers.";
+const P_H: &str = "We've implemented a temporary fix for the missing `WindowResize` in `tuirealms
+backend adapter for `termion`. We should add this to upstream.
+
+│We could create a thread that listens on signals and then send over a channel to
+the UI thread:
+```
+pub fn signals(channel: chan::Sender<Signal>) -> Result<(), Error> {
+    use signal_hook::consts::signal::*;
+    let mut signals = signal_hook::iterator::Signals::new([SIGWINCH, SIGINT])?;
+    for signal in signals.forever() {
+        match signal {
+            SIGWINCH => channel.send(Signal::WindowResized)?,
+            SIGINT => channel.send(Signal::Interrupted)?,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+```";
+
+#[derive(Debug)]
+struct Performance {
+    pub render_time: u128,
+}
+
+struct App<'a> {
+    tree: StatefulTree<'a>,
+    performance: Performance,
+}
+
+impl<'a> App<'a> {
+    fn new() -> Self {
+        let constraints = vec![Constraint::Length(1), Constraint::Max(8)];
+
+        let mut tree = StatefulTree::with_items(vec![
+            TreeItem::new_leaf("# A"),
+            TreeItem::new(
+                "# B",
+                vec![
+                    TreeItem::new_leaf("# C"),
+                    TreeItem::new(
+                        "# D",
+                        vec![TreeItem::new_leaf("# E"), TreeItem::new_leaf("# F")],
+                    ),
+                    TreeItem::new_leaf("# G")
+                        .paragraph(P_G)
+                        .heights(&constraints),
+                ],
+            ),
+            TreeItem::new_leaf("# H")
+                .paragraph(P_H)
+                .heights(&constraints),
+        ]);
+        tree.first();
+
+        let performance = Performance { render_time: 0 };
+        Self { tree, performance }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Terminal initialization
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // App
+    let app = App::new();
+    let res = run_app(&mut terminal, app);
+
+    // restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    if let Err(err) = res {
+        println!("{:?}", err);
+    }
+
+    Ok(())
+}
+
+fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
+    loop {
+        let now = SystemTime::now();
+        terminal.draw(|f| {
+            let area = f.size();
+
+            let items = MultilineTree::new(app.tree.items.clone())
+                .block(Block::default().borders(Borders::ALL).title(format!(
+                    "Tree Widget {:?} {:?}",
+                    app.tree.state, app.performance
+                )))
+                .item_block(Block::default().borders(Borders::ALL))
+                .item_block_highlight(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .style(Style::default().fg(Color::LightGreen)),
+                )
+                .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+            f.render_stateful_widget(items, area, &mut app.tree.state);
+        })?;
+
+        let elapsed = now.elapsed().unwrap_or_default();
+        app.performance.render_time = elapsed.as_millis();
+
+        if let Event::Key(key) = event::read()? {
+            match key.code {
+                KeyCode::Char('q') => return Ok(()),
+                KeyCode::Char('\n' | ' ') => app.tree.toggle(),
+                KeyCode::Left => app.tree.left(),
+                KeyCode::Right => app.tree.right(),
+                KeyCode::Down => app.tree.down(),
+                KeyCode::Up => app.tree.up(),
+                KeyCode::Home => app.tree.first(),
+                KeyCode::End => app.tree.last(),
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1,0 +1,153 @@
+use std::{error::Error, fmt};
+
+use std::iter::zip;
+use std::vec;
+
+use tui::layout::{Alignment, Constraint};
+use tui::style::Style;
+use tui::text::StyledGrapheme;
+
+use crate::reflow::{LineComposer, WordWrapper};
+use crate::{Flattened, TreeItem};
+
+#[derive(Debug)]
+pub enum ComposeError {
+    Constraint(Constraint),
+}
+
+impl Error for ComposeError {}
+
+impl fmt::Display for ComposeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ComposeError::Constraint(constraint) => {
+                write!(f, "Invalid constraint given: {:?}", constraint)
+            }
+        }
+    }
+}
+
+enum ComposeMode {
+    Fit(usize),
+    Fill(usize, usize),
+    Truncate(usize),
+}
+
+pub struct Composed<'a> {
+    identifier: Vec<usize>,
+    item: &'a TreeItem<'a>,
+    text: Vec<Vec<StyledGrapheme<'a>>>,
+}
+
+impl<'a> Composed<'a> {
+    #[must_use]
+    pub fn depth(&self) -> usize {
+        self.identifier.len() - 1
+    }
+
+    #[must_use]
+    pub fn height(&self) -> usize {
+        self.text.len()
+    }
+
+    #[must_use]
+    pub fn identifier(&self) -> &Vec<usize> {
+        &self.identifier
+    }
+
+    #[must_use]
+    pub fn style(&self) -> Style {
+        self.item.style
+    }
+
+    #[must_use]
+    pub fn text(&self) -> &Vec<Vec<StyledGrapheme<'a>>> {
+        &self.text
+    }
+
+    #[must_use]
+    pub fn has_children(&self) -> bool {
+        !self.item.children.is_empty()
+    }
+}
+
+#[must_use]
+pub fn compose<'a>(
+    items: &'a [Flattened<'a>],
+    width: u16,
+    truncation_symbol: &'a str,
+) -> Result<Vec<Composed<'a>>, ComposeError> {
+    items
+        .iter()
+        .map(|flattened| {
+            let mut composed = vec![];
+
+            let heights = &flattened.item().heights;
+            let paragraphs = &flattened.item().paragraphs;
+
+            for (height, paragraph) in zip(heights, paragraphs) {
+                let styled = paragraph.lines.iter().map(|line| {
+                    (
+                        line.0
+                            .iter()
+                            .flat_map(|span| span.styled_graphemes(flattened.item().style)),
+                        Alignment::Left,
+                    )
+                });
+
+                let mut composer = Box::new(WordWrapper::new(
+                    styled,
+                    width.saturating_sub(flattened.depth() as u16 * 2),
+                    false,
+                ));
+
+                let mut lines = vec![];
+                while let Some((line, _, _)) = composer.next_line() {
+                    lines.push(line.to_vec());
+                }
+
+                let lines = match compose_mode(lines.len(), *height)? {
+                    ComposeMode::Fit(take) => lines.into_iter().take(take).collect::<Vec<_>>(),
+                    ComposeMode::Fill(take, fill) => {
+                        let mut lines = lines.into_iter().take(take).collect::<Vec<_>>();
+                        lines.extend((0..fill).into_iter().map(|_| vec![]).collect::<Vec<_>>());
+                        lines
+                    }
+                    ComposeMode::Truncate(take) => {
+                        let mut lines = lines.into_iter().take(take).collect::<Vec<_>>();
+                        lines.push(vec![StyledGrapheme {
+                            symbol: truncation_symbol,
+                            style: flattened.item().style,
+                        }]);
+                        lines
+                    }
+                };
+
+                composed.extend(lines);
+            }
+
+            Ok(Composed {
+                identifier: flattened.identifier().clone(),
+                item: flattened.item(),
+                text: composed,
+            })
+        })
+        .collect()
+}
+
+fn compose_mode(len: usize, constraint: Constraint) -> Result<ComposeMode, ComposeError> {
+    let height = match constraint {
+        Constraint::Length(height) => height,
+        Constraint::Min(height) => std::cmp::max(len as u16, height),
+        Constraint::Max(height) => std::cmp::min(len as u16, height),
+        _ => return Err(ComposeError::Constraint(constraint).into()),
+    } as usize;
+
+    if len == height {
+        Ok(ComposeMode::Fit(height))
+    } else if len < height {
+        Ok(ComposeMode::Fill(height, height.saturating_sub(len)))
+    } else {
+        Ok(ComposeMode::Truncate(height.saturating_sub(1)))
+    }
+}

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -2,14 +2,22 @@ use crate::identifier::{TreeIdentifier, TreeIdentifierVec};
 use crate::TreeItem;
 
 pub struct Flattened<'a> {
-    pub identifier: Vec<usize>,
-    pub item: &'a TreeItem<'a>,
+    identifier: Vec<usize>,
+    item: &'a TreeItem<'a>,
 }
 
 impl<'a> Flattened<'a> {
     #[must_use]
     pub fn depth(&self) -> usize {
         self.identifier.len() - 1
+    }
+
+    pub fn identifier(&self) -> &Vec<usize> {
+        &self.identifier
+    }
+
+    pub fn item(&self) -> &TreeItem {
+        self.item
     }
 }
 
@@ -79,7 +87,7 @@ fn get_opened_nothing_opened_is_top_level() {
     let result = flatten(&[], &items);
     let result_text = result
         .iter()
-        .map(|o| get_naive_string_from_text(&o.item.text))
+        .map(|o| get_naive_string_from_text(&o.item.paragraphs[0]))
         .collect::<Vec<_>>();
     assert_eq!(result_text, ["a", "b", "h"]);
 }
@@ -91,7 +99,7 @@ fn get_opened_wrong_opened_is_only_top_level() {
     let result = flatten(&opened, &items);
     let result_text = result
         .iter()
-        .map(|o| get_naive_string_from_text(&o.item.text))
+        .map(|o| get_naive_string_from_text(&o.item.paragraphs[0]))
         .collect::<Vec<_>>();
     assert_eq!(result_text, ["a", "b", "h"]);
 }
@@ -103,7 +111,7 @@ fn get_opened_one_is_opened() {
     let result = flatten(&opened, &items);
     let result_text = result
         .iter()
-        .map(|o| get_naive_string_from_text(&o.item.text))
+        .map(|o| get_naive_string_from_text(&o.item.paragraphs[0]))
         .collect::<Vec<_>>();
     assert_eq!(result_text, ["a", "b", "c", "d", "g", "h"]);
 }
@@ -115,7 +123,7 @@ fn get_opened_all_opened() {
     let result = flatten(&opened, &items);
     let result_text = result
         .iter()
-        .map(|o| get_naive_string_from_text(&o.item.text))
+        .map(|o| get_naive_string_from_text(&o.item.paragraphs[0]))
         .collect::<Vec<_>>();
     assert_eq!(result_text, ["a", "b", "c", "d", "e", "f", "g", "h"]);
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1,0 +1,206 @@
+use std::{collections::VecDeque, vec::IntoIter};
+
+use unicode_width::UnicodeWidthStr;
+
+use tui::{layout::Alignment, text::StyledGrapheme};
+
+const NBSP: &str = "\u{00a0}";
+
+/// A state machine to pack styled symbols into lines.
+/// Cannot implement it as Iterator since it yields slices of the internal buffer (need streaming
+/// iterators for that).
+pub trait LineComposer<'a> {
+    fn next_line(&mut self) -> Option<(&[StyledGrapheme<'a>], u16, Alignment)>;
+}
+
+/// A state machine that wraps lines on word boundaries.
+pub struct WordWrapper<'a, O, I>
+where
+    // Outer iterator providing the individual lines
+    O: Iterator<Item = (I, Alignment)>,
+    // Inner iterator providing the styled symbols of a line Each line consists of an alignment and
+    // a series of symbols
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    /// The given, unprocessed lines
+    input_lines: O,
+    max_line_width: u16,
+    wrapped_lines: Option<IntoIter<Vec<StyledGrapheme<'a>>>>,
+    current_alignment: Alignment,
+    current_line: Vec<StyledGrapheme<'a>>,
+    /// Removes the leading whitespace from lines
+    trim: bool,
+}
+
+impl<'a, O, I> WordWrapper<'a, O, I>
+where
+    O: Iterator<Item = (I, Alignment)>,
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    pub fn new(lines: O, max_line_width: u16, trim: bool) -> WordWrapper<'a, O, I> {
+        WordWrapper {
+            input_lines: lines,
+            max_line_width,
+            wrapped_lines: None,
+            current_alignment: Alignment::Left,
+            current_line: vec![],
+            trim,
+        }
+    }
+}
+
+impl<'a, O, I> LineComposer<'a> for WordWrapper<'a, O, I>
+where
+    O: Iterator<Item = (I, Alignment)>,
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    fn next_line(&mut self) -> Option<(&[StyledGrapheme<'a>], u16, Alignment)> {
+        if self.max_line_width == 0 {
+            return None;
+        }
+
+        let mut current_line: Option<Vec<StyledGrapheme<'a>>> = None;
+        let mut line_width: u16 = 0;
+
+        // Try to repeatedly retrieve next line
+        while current_line.is_none() {
+            // Retrieve next preprocessed wrapped line
+            if let Some(line_iterator) = &mut self.wrapped_lines {
+                if let Some(line) = line_iterator.next() {
+                    line_width = line
+                        .iter()
+                        .map(|grapheme| grapheme.symbol.width())
+                        .sum::<usize>() as u16;
+                    current_line = Some(line);
+                }
+            }
+
+            // When no more preprocessed wrapped lines
+            if current_line.is_none() {
+                // Try to calculate next wrapped lines based on current whole line
+                if let Some((line_symbols, line_alignment)) = &mut self.input_lines.next() {
+                    // Save the whole line's alignment
+                    self.current_alignment = *line_alignment;
+                    let mut wrapped_lines = vec![]; // Saves the wrapped lines
+                                                    // Saves the unfinished wrapped line
+                    let (mut current_line, mut current_line_width) = (vec![], 0);
+                    // Saves the partially processed word
+                    let (mut unfinished_word, mut word_width) = (vec![], 0);
+                    // Saves the whitespaces of the partially unfinished word
+                    let (mut unfinished_whitespaces, mut whitespace_width) =
+                        (VecDeque::<StyledGrapheme>::new(), 0);
+
+                    let mut has_seen_non_whitespace = false;
+                    for StyledGrapheme { symbol, style } in line_symbols {
+                        let symbol_whitespace =
+                            symbol.chars().all(&char::is_whitespace) && symbol != NBSP;
+                        let symbol_width = symbol.width() as u16;
+                        // Ignore characters wider than the total max width
+                        if symbol_width > self.max_line_width {
+                            continue;
+                        }
+
+                        // Append finished word to current line
+                        if has_seen_non_whitespace && symbol_whitespace
+                            // Append if trimmed (whitespaces removed) word would overflow
+                            || word_width + symbol_width > self.max_line_width && current_line.is_empty() && self.trim
+                            // Append if removed whitespace would overflow -> reset whitespace counting to prevent overflow
+                            || whitespace_width + symbol_width > self.max_line_width && current_line.is_empty() && self.trim
+                            // Append if complete word would overflow
+                            || word_width + whitespace_width + symbol_width > self.max_line_width && current_line.is_empty() && !self.trim
+                        {
+                            if !current_line.is_empty() || !self.trim {
+                                // Also append whitespaces if not trimming or current line is not
+                                // empty
+                                current_line.extend(
+                                    std::mem::take(&mut unfinished_whitespaces).into_iter(),
+                                );
+                                current_line_width += whitespace_width;
+                            }
+                            // Append trimmed word
+                            current_line.append(&mut unfinished_word);
+                            current_line_width += word_width;
+
+                            // Clear whitespace buffer
+                            unfinished_whitespaces.clear();
+                            whitespace_width = 0;
+                            word_width = 0;
+                        }
+
+                        // Append the unfinished wrapped line to wrapped lines if it is as wide as
+                        // max line width
+                        if current_line_width >= self.max_line_width
+                            // or if it would be too long with the current partially processed word added
+                            || current_line_width + whitespace_width + word_width >= self.max_line_width && symbol_width > 0
+                        {
+                            let mut remaining_width =
+                                (self.max_line_width as i32 - current_line_width as i32).max(0)
+                                    as u16;
+                            wrapped_lines.push(std::mem::take(&mut current_line));
+                            current_line_width = 0;
+
+                            // Remove all whitespaces till end of just appended wrapped line + next
+                            // whitespace
+                            let mut first_whitespace = unfinished_whitespaces.pop_front();
+                            while let Some(grapheme) = first_whitespace.as_ref() {
+                                let symbol_width = grapheme.symbol.width() as u16;
+                                whitespace_width -= symbol_width;
+
+                                if symbol_width > remaining_width {
+                                    break;
+                                }
+                                remaining_width -= symbol_width;
+                                first_whitespace = unfinished_whitespaces.pop_front();
+                            }
+                            // In case all whitespaces have been exhausted
+                            if symbol_whitespace && first_whitespace.is_none() {
+                                // Prevent first whitespace to count towards next word
+                                continue;
+                            }
+                        }
+
+                        // Append symbol to unfinished, partially processed word
+                        if symbol_whitespace {
+                            whitespace_width += symbol_width;
+                            unfinished_whitespaces.push_back(StyledGrapheme { symbol, style });
+                        } else {
+                            word_width += symbol_width;
+                            unfinished_word.push(StyledGrapheme { symbol, style });
+                        }
+
+                        has_seen_non_whitespace = !symbol_whitespace;
+                    }
+
+                    // Append remaining text parts
+                    if !unfinished_word.is_empty() || !unfinished_whitespaces.is_empty() {
+                        if current_line.is_empty() && unfinished_word.is_empty() {
+                            wrapped_lines.push(vec![]);
+                        } else if !self.trim || !current_line.is_empty() {
+                            current_line.extend(unfinished_whitespaces.into_iter());
+                        }
+                        current_line.append(&mut unfinished_word);
+                    }
+                    if !current_line.is_empty() {
+                        wrapped_lines.push(current_line);
+                    }
+                    if wrapped_lines.is_empty() {
+                        // Append empty line if there was nothing to wrap in the first place
+                        wrapped_lines.push(vec![]);
+                    }
+
+                    self.wrapped_lines = Some(wrapped_lines.into_iter());
+                } else {
+                    // No more whole lines available -> stop repeatedly retrieving next wrapped line
+                    break;
+                }
+            }
+        }
+
+        if let Some(line) = current_line {
+            self.current_line = line;
+            Some((&self.current_line[..], line_width, self.current_alignment))
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Currently, tree items can not wrap or truncate text on their own. It would be very helpful if there was a way to define wrapping, truncation and filling constraints that allow multi-line text items. Multi-line tree items might also need to be rendered inside a block for a better visual experience.

### Implementation

This changes `TreeItem` to have multiple texts that can be composed with optional layout constraints. It adds a new `MultilineTree` which can compose items by truncating / wrapping / filling their texts based on the constraints given.

This PR clones the (not yet public) `reflow` module of `ratatui`. When it's been made public through https://github.com/tui-rs-revival/ratatui/pull/9, this can be removed again.

A `MultilineTree` can also be styled differently now: it allows defining blocks in which the composed text is rendered in.

### Discussion

- Shall this be rather implemented as a tree of widgets? There's some ongoing work that could help implementing this: https://github.com/tui-rs-revival/ratatui/pull/217
- If the current implementation as multi-line item is fine, shared code between the `Tree` and `MultilineTree` should probably be factored out