### PR TITLE
feat: add ratatui feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       - run: cargo fmt --check --verbose
 
   test:
-    name: Test ${{ matrix.toolchain }} ${{ matrix.os }}
+    name: Test ${{ matrix.toolchain }} ${{ matrix.os }} ${{ matrix.features }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
@@ -36,6 +36,9 @@ jobs:
         clippyargs:
           - -D clippy::pedantic -D warnings
         features:
+          - "" # default features
+          - --no-default-features --features tui
+          - --no-default-features --features ratatui
           - --all-features
         include:
           # Check future versions and maybe get some glances on soon to be lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,18 @@ categories = ["command-line-interface"]
 include = ["src/**/*", "README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[example]]
+name = "example"
+required-features = ["ratatui"]
+
+[features]
+default = ["tui"]
+
 [dependencies]
-tui = { version = "0.19", default-features = false }
+ratatui = { version = "0.21", default-features = false, optional = true }
+tui = { version = "0.19", default-features = false, optional = true }
 unicode-width = "0.1"
 
 [dev-dependencies]
-crossterm = "0.25"
-tui = "0.19"
+crossterm = "0.26"
+ratatui = "0.21"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -6,13 +6,13 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use std::{error::Error, io};
-use tui::{
+use ratatui::{
     backend::{Backend, CrosstermBackend},
     style::{Color, Modifier, Style},
     widgets::{Block, Borders},
     Terminal,
 };
+use std::{error::Error, io};
 
 use tui_tree_widget::{Tree, TreeItem};
 

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -45,8 +45,20 @@ fn internal<'a>(
     result
 }
 
-#[cfg(test)]
-fn get_naive_string_from_text(text: &tui::text::Text<'_>) -> String {
+#[cfg(all(test, feature = "ratatui"))]
+fn get_naive_string_from_text(text: &crate::tui::text::Text<'_>) -> String {
+    text.lines
+        .first()
+        .unwrap()
+        .spans
+        .first()
+        .unwrap()
+        .content
+        .to_string()
+}
+
+#[cfg(all(test, not(feature = "ratatui")))]
+fn get_naive_string_from_text(text: &crate::tui::text::Text<'_>) -> String {
     text.lines
         .first()
         .unwrap()

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -46,7 +46,7 @@ fn internal<'a>(
 }
 
 #[cfg(all(test, feature = "ratatui"))]
-fn get_naive_string_from_text(text: &crate::tui::text::Text<'_>) -> String {
+fn get_naive_string_from_text(text: &ratatui::text::Text<'_>) -> String {
     text.lines
         .first()
         .unwrap()
@@ -58,7 +58,7 @@ fn get_naive_string_from_text(text: &crate::tui::text::Text<'_>) -> String {
 }
 
 #[cfg(all(test, not(feature = "ratatui")))]
-fn get_naive_string_from_text(text: &crate::tui::text::Text<'_>) -> String {
+fn get_naive_string_from_text(text: &tui::text::Text<'_>) -> String {
     text.lines
         .first()
         .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,19 @@
 #![forbid(unsafe_code)]
 
-use std::collections::HashSet;
+#[cfg(feature = "ratatui")]
+pub(crate) use ratatui as tui;
+#[cfg(not(feature = "ratatui"))]
+#[allow(clippy::single_component_path_imports)]
+pub(crate) use tui;
 
-use tui::buffer::Buffer;
-use tui::layout::{Corner, Rect};
-use tui::style::Style;
-use tui::text::Text;
-use tui::widgets::{Block, StatefulWidget, Widget};
+use self::tui::{
+    buffer::Buffer,
+    layout::{Corner, Rect},
+    style::Style,
+    text::Text,
+    widgets::{Block, StatefulWidget, Widget},
+};
+use std::collections::HashSet;
 use unicode_width::UnicodeWidthStr;
 
 mod flatten;
@@ -247,9 +254,10 @@ impl<'a> TreeItem<'a> {
 ///
 /// ```
 /// # use tui_tree_widget::{Tree, TreeItem, TreeState};
-/// # use tui::backend::TestBackend;
-/// # use tui::Terminal;
-/// # use tui::widgets::{Block, Borders};
+#[cfg_attr(feature = "ratatui", doc = "# use ratatui::{")]
+#[cfg_attr(not(feature = "ratatui"), doc = "# use tui::{")]
+/// #   backend::TestBackend, Terminal, widgets::{Block, Borders}};
+/// #
 /// # fn main() -> std::io::Result<()> {
 /// #     let mut terminal = Terminal::new(TestBackend::new(32, 32)).unwrap();
 /// let mut state = TreeState::default();
@@ -480,7 +488,11 @@ impl<'a> StatefulWidget for Tree<'a> {
 
             let max_element_width = area.width.saturating_sub(after_depth_x - x);
             for (j, line) in item.item.text.lines.iter().enumerate() {
-                buf.set_spans(after_depth_x, y + j as u16, line, max_element_width);
+                let y_j = y + j as u16;
+                #[cfg(feature = "ratatui")]
+                buf.set_line(after_depth_x, y_j, line, max_element_width);
+                #[cfg(not(feature = "ratatui"))]
+                buf.set_spans(after_depth_x, y_j, line, max_element_width);
             }
             if is_selected {
                 buf.set_style(area, self.highlight_style);


### PR DESCRIPTION
The code in itself is not a breaking change so it could be released as v0.12.1.
Sadly ratatui requires Rust 1.65 (Debian 12 bookworm has 1.63) so this could be considered breaking…

see #18 
closes #21