### PR TITLE
feat: add option to show only visible items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ impl TreeState {
 pub struct TreeItem<'a> {
     text: Text<'a>,
     style: Style,
+    is_visible: bool,
     children: Vec<TreeItem<'a>>,
 }
 
@@ -193,12 +194,13 @@ impl<'a> TreeItem<'a> {
         Self {
             text: text.into(),
             style: Style::default(),
+            is_visible: true,
             children: Vec::new(),
         }
     }
 
     #[must_use]
-    pub fn new<T, Children>(text: T, children: Children) -> Self
+    pub fn new<T, Children>(text: T, children: Children, is_visible: bool) -> Self
     where
         T: Into<Text<'a>>,
         Children: Into<Vec<TreeItem<'a>>>,
@@ -206,6 +208,7 @@ impl<'a> TreeItem<'a> {
         Self {
             text: text.into(),
             style: Style::default(),
+            is_visible,
             children: children.into(),
         }
     }
@@ -377,7 +380,10 @@ impl<'a> StatefulWidget for Tree<'a> {
             return;
         }
 
-        let visible = flatten(&state.get_all_opened(), &self.items);
+        let visible = flatten(&state.get_all_opened(), &self.items)
+            .into_iter()
+            .filter(|i| i.item.is_visible)
+            .collect::<Vec<_>>();
         if visible.is_empty() {
             return;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,7 @@ impl<'a> TreeItem<'a> {
     }
 
     #[must_use]
-    pub fn new<T, Children>(text: T, children: Children, is_visible: bool) -> Self
+    pub fn new<T, Children>(text: T, children: Children) -> Self
     where
         T: Into<Text<'a>>,
         Children: Into<Vec<TreeItem<'a>>>,
@@ -208,7 +208,7 @@ impl<'a> TreeItem<'a> {
         Self {
             text: text.into(),
             style: Style::default(),
-            is_visible,
+            is_visible: true,
             children: children.into(),
         }
     }
@@ -236,6 +236,11 @@ impl<'a> TreeItem<'a> {
     #[must_use]
     pub const fn style(mut self, style: Style) -> Self {
         self.style = style;
+        self
+    }
+
+    pub const fn visible(mut self, visible: bool) -> Self {
+        self.is_visible = visible;
         self
     }
 


### PR DESCRIPTION
I was adding a `filter/search` feature to your [mqttui](https://github.com/EdJoPaTo/mqttui) project, so I needed to be able to render only items that qualified the search query. To achieve this, I added an **`is_visible`** option to the **`TreeItem`** struct and a function to change the item's visibility. Additionally, these changes are backward-compatible.