### PR TITLE
feat: TreeItem trait

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,66 +4,62 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughpu
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::widgets::StatefulWidget;
-use tui_tree_widget::{Selector, Tree, TreeItem, TreeState};
+use tui_tree_widget::json::JsonTreeItem;
+use tui_tree_widget::{Selector, SimpleTreeItem, Tree, TreeState};
 
-fn example_items() -> Vec<TreeItem<'static, &'static str>> {
+fn example_items() -> Vec<SimpleTreeItem<'static>> {
     vec![
-        TreeItem::new_leaf("a", "Alfa"),
-        TreeItem::new(
-            "b",
+        SimpleTreeItem::new_leaf("Alfa"),
+        SimpleTreeItem::new(
             "Bravo",
             vec![
-                TreeItem::new_leaf("c", "Charlie"),
-                TreeItem::new(
-                    "d",
+                SimpleTreeItem::new_leaf("Charlie"),
+                SimpleTreeItem::new(
                     "Delta",
                     vec![
-                        TreeItem::new_leaf("e", "Echo"),
-                        TreeItem::new_leaf("f", "Foxtrot"),
+                        SimpleTreeItem::new_leaf("Echo"),
+                        SimpleTreeItem::new_leaf("Foxtrot"),
                     ],
                 )
                 .expect("all item identifiers are unique"),
-                TreeItem::new_leaf("g", "Golf"),
+                SimpleTreeItem::new_leaf("Golf"),
             ],
         )
         .expect("all item identifiers are unique"),
-        TreeItem::new_leaf("h", "Hotel"),
-        TreeItem::new(
-            "i",
+        SimpleTreeItem::new_leaf("Hotel"),
+        SimpleTreeItem::new(
             "India",
             vec![
-                TreeItem::new_leaf("j", "Juliett"),
-                TreeItem::new_leaf("k", "Kilo"),
-                TreeItem::new_leaf("l", "Lima"),
-                TreeItem::new_leaf("m", "Mike"),
-                TreeItem::new_leaf("n", "November"),
+                SimpleTreeItem::new_leaf("Juliett"),
+                SimpleTreeItem::new_leaf("Kilo"),
+                SimpleTreeItem::new_leaf("Lima"),
+                SimpleTreeItem::new_leaf("Mike"),
+                SimpleTreeItem::new_leaf("November"),
             ],
         )
         .expect("all item identifiers are unique"),
-        TreeItem::new_leaf("o", "Oscar"),
-        TreeItem::new(
-            "p",
+        SimpleTreeItem::new_leaf("Oscar"),
+        SimpleTreeItem::new(
             "Papa",
             vec![
-                TreeItem::new_leaf("q", "Quebec"),
-                TreeItem::new_leaf("r", "Romeo"),
-                TreeItem::new_leaf("s", "Sierra"),
-                TreeItem::new_leaf("t", "Tango"),
-                TreeItem::new_leaf("u", "Uniform"),
-                TreeItem::new(
-                    "v",
+                SimpleTreeItem::new_leaf("Quebec"),
+                SimpleTreeItem::new_leaf("Romeo"),
+                SimpleTreeItem::new_leaf("Sierra"),
+                SimpleTreeItem::new_leaf("Tango"),
+                SimpleTreeItem::new_leaf("Uniform"),
+                SimpleTreeItem::new(
                     "Victor",
                     vec![
-                        TreeItem::new_leaf("w", "Whiskey"),
-                        TreeItem::new_leaf("x", "Xray"),
-                        TreeItem::new_leaf("y", "Yankee"),
+                        SimpleTreeItem::new_leaf("Whiskey"),
+                        SimpleTreeItem::new_leaf("Xray"),
+                        SimpleTreeItem::new_leaf("Yankee"),
                     ],
                 )
                 .expect("all item identifiers are unique"),
             ],
         )
         .expect("all item identifiers are unique"),
-        TreeItem::new_leaf("z", "Zulu"),
+        SimpleTreeItem::new_leaf("Zulu"),
     ]
 }
 
@@ -120,7 +116,7 @@ fn init(criterion: &mut Criterion) {
 
     group.bench_function("empty", |bencher| {
         bencher.iter(|| {
-            let items: Vec<TreeItem<usize>> = vec![];
+            let items: Vec<SimpleTreeItem> = vec![];
             black_box(Tree::new(black_box(items))).unwrap();
         });
     });
@@ -135,7 +131,7 @@ fn init(criterion: &mut Criterion) {
     let metadata = metadata();
     group.bench_function("metadata", |bencher| {
         bencher.iter(|| {
-            black_box(Tree::new(tui_tree_widget::json::tree_items(black_box(&metadata))).unwrap());
+            black_box(Tree::new(JsonTreeItem::new(black_box(&metadata))).unwrap());
         });
     });
 
@@ -149,7 +145,7 @@ fn renders(criterion: &mut Criterion) {
     let buffer_size = Rect::new(0, 0, 100, 100);
 
     group.bench_function("empty", |bencher| {
-        let items: Vec<TreeItem<usize>> = vec![];
+        let items: Vec<SimpleTreeItem> = vec![];
         let tree = Tree::new(items).unwrap();
         let mut state = TreeState::default();
         bencher.iter_batched(
@@ -179,7 +175,7 @@ fn renders(criterion: &mut Criterion) {
     let metadata = metadata();
 
     group.bench_function("metadata/no_open", |bencher| {
-        let tree = Tree::new(tui_tree_widget::json::tree_items(&metadata)).unwrap();
+        let tree = Tree::new(JsonTreeItem::new(&metadata)).unwrap();
         let mut state = TreeState::default();
         bencher.iter_batched(
             || (tree.clone(), Buffer::empty(buffer_size)),
@@ -191,7 +187,7 @@ fn renders(criterion: &mut Criterion) {
     });
 
     group.bench_function("metadata/few_open", |bencher| {
-        let tree = Tree::new(tui_tree_widget::json::tree_items(&metadata)).unwrap();
+        let tree = Tree::new(JsonTreeItem::new(&metadata)).unwrap();
         let mut state = TreeState::default();
         state.open(vec![key("packages")]);
         state.open(vec![key("packages"), Selector::ArrayIndex(0)]);
@@ -208,7 +204,7 @@ fn renders(criterion: &mut Criterion) {
     });
 
     group.bench_function("metadata/all_open", |bencher| {
-        let tree = Tree::new(tui_tree_widget::json::tree_items(&metadata)).unwrap();
+        let tree = Tree::new(JsonTreeItem::new(&metadata)).unwrap();
         let mut state = TreeState::default();
         open_all(&mut state, &metadata, &[]);
         bencher.iter_batched(

--- a/examples/cargo_metadata.rs
+++ b/examples/cargo_metadata.rs
@@ -9,6 +9,7 @@ use ratatui::text::Span;
 use ratatui::widgets::{Block, Scrollbar, ScrollbarOrientation};
 use ratatui::{Frame, Terminal};
 use serde_json::Value;
+use tui_tree_widget::json::JsonTreeItem;
 use tui_tree_widget::{Selector, Tree, TreeState};
 
 struct App {
@@ -37,7 +38,7 @@ impl App {
 
     fn draw(&mut self, frame: &mut Frame) {
         let area = frame.size();
-        let widget = Tree::new(tui_tree_widget::json::tree_items(&self.metadata))
+        let widget = Tree::new(JsonTreeItem::new(&self.metadata))
             .expect("JSON Should always have unique identifiers")
             .block(
                 Block::bordered()

--- a/examples/custom_tree_item.rs
+++ b/examples/custom_tree_item.rs
@@ -9,79 +9,122 @@ use ratatui::widgets::{Block, Scrollbar, ScrollbarOrientation};
 use ratatui::{Frame, Terminal};
 use tui_tree_widget::{Tree, TreeItem, TreeState};
 
+struct MyTreeItem<'content> {
+    identifier: String,
+    content: &'content str,
+    children: Vec<Self>,
+}
+
+impl TreeItem for MyTreeItem<'_> {
+    type Identifier = String;
+
+    fn children(&self) -> &[Self] {
+        &self.children
+    }
+
+    fn height(&self) -> usize {
+        // We know that every item will have exactly the height 1
+        1
+    }
+
+    fn identifier(&self) -> &Self::Identifier {
+        &self.identifier
+    }
+
+    fn render(&self, area: ratatui::layout::Rect, buffer: &mut ratatui::buffer::Buffer) {
+        let line = ratatui::text::Line::raw(self.content);
+        ratatui::widgets::Widget::render(line, area, buffer);
+    }
+}
+
+impl<'content> MyTreeItem<'content> {
+    fn new_leaf(identifier: &str, content: &'content str) -> Self {
+        Self {
+            identifier: identifier.to_owned(),
+            content,
+            children: Vec::new(),
+        }
+    }
+
+    fn new(identifier: &str, content: &'content str, children: Vec<Self>) -> Self {
+        tui_tree_widget::unique_identifiers::children(&children)
+            .expect("all item identifiers are unique");
+        Self {
+            identifier: identifier.to_owned(),
+            content,
+            children,
+        }
+    }
+
+    fn example() -> Vec<Self> {
+        vec![
+            Self::new_leaf("a", "Alfa"),
+            Self::new(
+                "b",
+                "Bravo",
+                vec![
+                    Self::new_leaf("c", "Charlie"),
+                    Self::new(
+                        "d",
+                        "Delta",
+                        vec![Self::new_leaf("e", "Echo"), Self::new_leaf("f", "Foxtrot")],
+                    ),
+                    Self::new_leaf("g", "Golf"),
+                ],
+            ),
+            Self::new_leaf("h", "Hotel"),
+            Self::new(
+                "i",
+                "India",
+                vec![
+                    Self::new_leaf("j", "Juliett"),
+                    Self::new_leaf("k", "Kilo"),
+                    Self::new_leaf("l", "Lima"),
+                    Self::new_leaf("m", "Mike"),
+                    Self::new_leaf("n", "November"),
+                ],
+            ),
+            Self::new_leaf("o", "Oscar"),
+            Self::new(
+                "p",
+                "Papa",
+                vec![
+                    Self::new_leaf("q", "Quebec"),
+                    Self::new_leaf("r", "Romeo"),
+                    Self::new_leaf("s", "Sierra"),
+                    Self::new_leaf("t", "Tango"),
+                    Self::new_leaf("u", "Uniform"),
+                    Self::new(
+                        "v",
+                        "Victor",
+                        vec![
+                            Self::new_leaf("w", "Whiskey"),
+                            Self::new_leaf("x", "Xray"),
+                            Self::new_leaf("y", "Yankee"),
+                        ],
+                    ),
+                ],
+            ),
+            Self::new_leaf("z", "Zulu"),
+        ]
+    }
+}
+
 struct App {
-    state: TreeState<&'static str>,
-    items: Vec<TreeItem<'static, &'static str>>,
+    state: TreeState<String>,
 }
 
 impl App {
     fn new() -> Self {
         Self {
             state: TreeState::default(),
-            items: vec![
-                TreeItem::new_leaf("a", "Alfa"),
-                TreeItem::new(
-                    "b",
-                    "Bravo",
-                    vec![
-                        TreeItem::new_leaf("c", "Charlie"),
-                        TreeItem::new(
-                            "d",
-                            "Delta",
-                            vec![
-                                TreeItem::new_leaf("e", "Echo"),
-                                TreeItem::new_leaf("f", "Foxtrot"),
-                            ],
-                        )
-                        .expect("all item identifiers are unique"),
-                        TreeItem::new_leaf("g", "Golf"),
-                    ],
-                )
-                .expect("all item identifiers are unique"),
-                TreeItem::new_leaf("h", "Hotel"),
-                TreeItem::new(
-                    "i",
-                    "India",
-                    vec![
-                        TreeItem::new_leaf("j", "Juliett"),
-                        TreeItem::new_leaf("k", "Kilo"),
-                        TreeItem::new_leaf("l", "Lima"),
-                        TreeItem::new_leaf("m", "Mike"),
-                        TreeItem::new_leaf("n", "November"),
-                    ],
-                )
-                .expect("all item identifiers are unique"),
-                TreeItem::new_leaf("o", "Oscar"),
-                TreeItem::new(
-                    "p",
-                    "Papa",
-                    vec![
-                        TreeItem::new_leaf("q", "Quebec"),
-                        TreeItem::new_leaf("r", "Romeo"),
-                        TreeItem::new_leaf("s", "Sierra"),
-                        TreeItem::new_leaf("t", "Tango"),
-                        TreeItem::new_leaf("u", "Uniform"),
-                        TreeItem::new(
-                            "v",
-                            "Victor",
-                            vec![
-                                TreeItem::new_leaf("w", "Whiskey"),
-                                TreeItem::new_leaf("x", "Xray"),
-                                TreeItem::new_leaf("y", "Yankee"),
-                            ],
-                        )
-                        .expect("all item identifiers are unique"),
-                    ],
-                )
-                .expect("all item identifiers are unique"),
-                TreeItem::new_leaf("z", "Zulu"),
-            ],
         }
     }
 
     fn draw(&mut self, frame: &mut Frame) {
         let area = frame.size();
-        let widget = Tree::new(self.items.clone())
+        let items = MyTreeItem::example();
+        let widget = Tree::new(items)
             .expect("all item identifiers are unique")
             .block(
                 Block::bordered()

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,5 +1,7 @@
-pub use self::render::tree_items;
+#![allow(clippy::module_name_repetitions)]
+
+pub use self::json_tree_item::JsonTreeItem;
 pub use self::select::select;
 
-mod render;
+mod json_tree_item;
 mod select;

--- a/src/prerendered_tree_item.rs
+++ b/src/prerendered_tree_item.rs
@@ -1,0 +1,116 @@
+use ratatui::text::Text;
+
+use super::TreeItem;
+
+/// One item inside a [`Tree`](crate::Tree).
+///
+/// For more information about the identifier see [`TreeItem::Identifier`].
+///
+/// # Performance
+///
+/// As this item accepts a [`Text`] it needs to be rendered with all the styles and so on before being created.
+/// This means the computation cost of this implementation is on the item creation.
+///
+/// When there are many `TreeItem`s not all of them will end up being actually shown.
+/// Some might be out of the view, some might be children not yet opened by the user.
+/// Therefore, this implementation takes a lot of performance for pre-rendering items that might not even be visible in the current view.
+///
+/// It might be easier to use this `PrerenderedTreeItem` in contrast to specialized implementations of [`TreeItem`] (like `JsonTreeItem`) or implementing one yourself, but it will not be as efficient performance wise.
+///
+/// # Example
+///
+/// ```
+/// # use tui_tree_widget::PrerenderedTreeItem;
+/// let a = PrerenderedTreeItem::new_leaf("l", "Leaf");
+/// let b = PrerenderedTreeItem::new("r", "Root", vec![a])?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct PrerenderedTreeItem<'text, Identifier> {
+    identifier: Identifier,
+    text: Text<'text>,
+    children: Vec<Self>,
+}
+
+impl<'text, Identifier> PrerenderedTreeItem<'text, Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + core::hash::Hash,
+{
+    /// Create a new `PrerenderedTreeItem` without children.
+    #[must_use]
+    pub fn new_leaf<T>(identifier: Identifier, text: T) -> Self
+    where
+        T: Into<Text<'text>>,
+    {
+        Self {
+            identifier,
+            text: text.into(),
+            children: Vec::new(),
+        }
+    }
+
+    /// Create a new `PrerenderedTreeItem` with children.
+    ///
+    /// # Errors
+    ///
+    /// Errors when there are duplicate identifiers in the children.
+    #[track_caller]
+    pub fn new<T>(identifier: Identifier, text: T, children: Vec<Self>) -> std::io::Result<Self>
+    where
+        T: Into<Text<'text>>,
+    {
+        crate::unique_identifiers::children(&children)?;
+        Ok(Self {
+            identifier,
+            text: text.into(),
+            children,
+        })
+    }
+
+    /// Get a reference to a child by index.
+    #[must_use]
+    pub fn child(&self, index: usize) -> Option<&Self> {
+        self.children.get(index)
+    }
+
+    /// Get a mutable reference to a child by index.
+    #[must_use]
+    pub fn child_mut(&mut self, index: usize) -> Option<&mut Self> {
+        self.children.get_mut(index)
+    }
+
+    /// Add a child.
+    ///
+    /// # Errors
+    ///
+    /// Errors when the `identifier` of the `child` already exists in the children.
+    #[track_caller]
+    pub fn add_child(&mut self, child: Self) -> std::io::Result<()> {
+        crate::unique_identifiers::add_child(&self.children, &child)?;
+        self.children.push(child);
+        Ok(())
+    }
+}
+
+impl<Identifier> TreeItem for PrerenderedTreeItem<'_, Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + core::hash::Hash,
+{
+    type Identifier = Identifier;
+
+    fn children(&self) -> &[Self] {
+        &self.children
+    }
+
+    fn height(&self) -> usize {
+        self.text.height()
+    }
+
+    fn identifier(&self) -> &Self::Identifier {
+        &self.identifier
+    }
+
+    fn render(&self, area: ratatui::layout::Rect, buffer: &mut ratatui::buffer::Buffer) {
+        ratatui::widgets::Widget::render(&self.text, area, buffer);
+    }
+}

--- a/src/simple_tree_item.rs
+++ b/src/simple_tree_item.rs
@@ -1,0 +1,103 @@
+use ratatui::style::Style;
+
+use super::TreeItem;
+
+/// Represents a very simple [`TreeItem`] implementation.
+///
+/// It assumes the text to be shown is only a single line element and each text is different.
+#[derive(Debug, Clone)]
+pub struct SimpleTreeItem<'text> {
+    text: &'text str,
+    style: Style,
+    children: Vec<SimpleTreeItem<'text>>,
+}
+
+impl<'text> SimpleTreeItem<'text> {
+    /// Create a new `SimpleTreeItem` without children.
+    #[must_use]
+    pub const fn new_leaf(text: &'text str) -> Self {
+        Self {
+            text,
+            style: Style::new(),
+            children: Vec::new(),
+        }
+    }
+
+    /// Create a new `SimpleTreeItem` with children.
+    ///
+    /// # Errors
+    ///
+    /// Errors when there are duplicate identifiers in the children.
+    #[track_caller]
+    pub fn new(text: &'text str, children: Vec<Self>) -> std::io::Result<Self> {
+        crate::unique_identifiers::children(&children)?;
+        Ok(Self {
+            text,
+            style: Style::new(),
+            children,
+        })
+    }
+}
+
+impl<'text> TreeItem for SimpleTreeItem<'text> {
+    type Identifier = &'text str;
+
+    fn identifier(&self) -> &Self::Identifier {
+        &self.text
+    }
+
+    fn children(&self) -> &[Self] {
+        &self.children
+    }
+
+    fn height(&self) -> usize {
+        1
+    }
+
+    fn render(&self, area: ratatui::layout::Rect, buffer: &mut ratatui::buffer::Buffer) {
+        use ratatui::style::Styled;
+        let text = self.text.set_style(self.style);
+        ratatui::widgets::Widget::render(text, area, buffer);
+    }
+}
+
+impl ratatui::style::Styled for SimpleTreeItem<'_> {
+    type Item = Self;
+
+    fn style(&self) -> Style {
+        self.style
+    }
+
+    fn set_style<S: Into<Style>>(mut self, style: S) -> Self::Item {
+        self.style = style.into();
+        self
+    }
+}
+
+impl SimpleTreeItem<'static> {
+    #[cfg(test)]
+    pub(crate) fn example() -> Vec<Self> {
+        vec![
+            Self::new_leaf("a"),
+            Self::new(
+                "b",
+                vec![
+                    Self::new_leaf("c"),
+                    Self::new("d", vec![Self::new_leaf("e"), Self::new_leaf("f")])
+                        .expect("all item identifiers are unique"),
+                    Self::new_leaf("g"),
+                ],
+            )
+            .expect("all item identifiers are unique"),
+            Self::new_leaf("h"),
+        ]
+    }
+}
+
+#[test]
+#[should_panic = "duplicate "]
+fn tree_item_new_errors_with_duplicate_identifiers() {
+    let item: SimpleTreeItem = SimpleTreeItem::new_leaf("same");
+    let another = SimpleTreeItem::new_leaf("same");
+    SimpleTreeItem::new("root", vec![item, another]).unwrap();
+}

--- a/src/tree_item.rs
+++ b/src/tree_item.rs
@@ -1,174 +1,47 @@
-use std::collections::HashSet;
-
-use ratatui::text::Text;
-
 /// One item inside a [`Tree`](crate::Tree).
 ///
 /// Can have zero or more `children`.
-///
-/// # Identifier
-///
-/// The generic argument `Identifier` is used to keep the state like the currently selected or opened [`TreeItem`]s in the [`TreeState`](crate::TreeState).
-///
-/// It needs to be unique among its siblings but can be used again on parent or child [`TreeItem`]s.
-/// A common example would be a filename which has to be unique in its directory while it can exist in another.
-///
-/// The `text` can be different from its `identifier`.
-/// To repeat the filename analogy: File browsers sometimes hide file extensions.
-/// The filename `main.rs` is the identifier while its shown as `main`.
-/// Two files `main.rs` and `main.toml` can exist in the same directory and can both be displayed as `main` but their identifier is different.
-///
-/// Just like every file in a file system can be uniquely identified with its file and directory names each [`TreeItem`] in a [`Tree`](crate::Tree) can be with these identifiers.
-/// As an example the following two identifiers describe the main file in a Rust cargo project: `vec!["src", "main.rs"]`.
-///
-/// The identifier does not need to be a `String` and is therefore generic.
-/// Until version 0.14 this crate used `usize` and indices.
-/// This might still be perfect for your use case.
-///
-/// # Example
-///
-/// ```
-/// # use tui_tree_widget::TreeItem;
-/// let a = TreeItem::new_leaf("l", "Leaf");
-/// let b = TreeItem::new("r", "Root", vec![a])?;
-/// # Ok::<(), std::io::Error>(())
-/// ```
-#[derive(Debug, Clone)]
-pub struct TreeItem<'text, Identifier> {
-    pub(super) identifier: Identifier,
-    pub(super) text: Text<'text>,
-    pub(super) children: Vec<Self>,
-}
-
-impl<'text, Identifier> TreeItem<'text, Identifier>
+pub trait TreeItem
 where
-    Identifier: Clone + PartialEq + Eq + core::hash::Hash,
+    Self: Sized,
 {
-    /// Create a new `TreeItem` without children.
-    #[must_use]
-    pub fn new_leaf<T>(identifier: Identifier, text: T) -> Self
-    where
-        T: Into<Text<'text>>,
-    {
-        Self {
-            identifier,
-            text: text.into(),
-            children: Vec::new(),
-        }
-    }
-
-    /// Create a new `TreeItem` with children.
+    /// Unique identifier of the item in the current depth.
     ///
-    /// # Errors
+    /// The identifier is used to keep the state like the currently selected or opened [`TreeItem`]s in the [`TreeState`](crate::TreeState).
     ///
-    /// Errors when there are duplicate identifiers in the children.
-    pub fn new<T>(identifier: Identifier, text: T, children: Vec<Self>) -> std::io::Result<Self>
-    where
-        T: Into<Text<'text>>,
-    {
-        let identifiers = children
-            .iter()
-            .map(|item| &item.identifier)
-            .collect::<HashSet<_>>();
-        if identifiers.len() != children.len() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
-                "The children contain duplicate identifiers",
-            ));
-        }
-
-        Ok(Self {
-            identifier,
-            text: text.into(),
-            children,
-        })
-    }
-
-    #[must_use]
-    pub fn children(&self) -> &[Self] {
-        &self.children
-    }
-
-    /// Get a reference to a child by index.
-    #[must_use]
-    pub fn child(&self, index: usize) -> Option<&Self> {
-        self.children.get(index)
-    }
-
-    /// Get a mutable reference to a child by index.
+    /// It needs to be unique among its siblings but can be used again on parent or child [`TreeItem`]s.
+    /// A common example would be a filename which has to be unique in its directory while it can exist in another.
     ///
-    /// When you choose to change the `identifier` the [`TreeState`](crate::TreeState) might not work as expected afterwards.
-    #[must_use]
-    pub fn child_mut(&mut self, index: usize) -> Option<&mut Self> {
-        self.children.get_mut(index)
-    }
-
-    #[must_use]
-    pub fn height(&self) -> usize {
-        self.text.height()
-    }
-
-    /// Add a child to the `TreeItem`.
+    /// What is rendered can be different from its `identifier`.
+    /// To repeat the filename analogy: File browsers sometimes hide file extensions.
+    /// The filename `main.rs` is the identifier while its shown as `main`.
+    /// Two files `main.rs` and `main.toml` can exist in the same directory and can both be displayed as `main` but their identifier is different.
     ///
-    /// # Errors
+    /// Just like every file in a file system can be uniquely identified with its file and directory names each [`TreeItem`] in a [`Tree`](crate::Tree) can be with these identifiers.
+    /// As an example the following two identifiers describe the main file in a Rust cargo project: `vec!["src", "main.rs"]`.
     ///
-    /// Errors when the `identifier` of the `child` already exists in the children.
-    pub fn add_child(&mut self, child: Self) -> std::io::Result<()> {
-        let existing = self
-            .children
-            .iter()
-            .map(|item| &item.identifier)
-            .collect::<HashSet<_>>();
-        if existing.contains(&child.identifier) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
-                "identifier already exists in the children",
-            ));
-        }
+    /// The identifier does not need to be a `String` and is therefore generic.
+    /// Until version 0.14 this crate used `usize` and indices.
+    /// This might still be perfect for your use case.
+    type Identifier: Clone + PartialEq + Eq + core::hash::Hash;
 
-        self.children.push(child);
-        Ok(())
-    }
-}
+    /// Returns the direct children of this item.
+    #[must_use]
+    fn children(&self) -> &[Self];
 
-impl TreeItem<'static, &'static str> {
-    #[cfg(test)]
-    pub(crate) fn example() -> Vec<Self> {
-        vec![
-            Self::new_leaf("a", "Alfa"),
-            Self::new(
-                "b",
-                "Bravo",
-                vec![
-                    Self::new_leaf("c", "Charlie"),
-                    Self::new(
-                        "d",
-                        "Delta",
-                        vec![Self::new_leaf("e", "Echo"), Self::new_leaf("f", "Foxtrot")],
-                    )
-                    .expect("all item identifiers are unique"),
-                    Self::new_leaf("g", "Golf"),
-                ],
-            )
-            .expect("all item identifiers are unique"),
-            Self::new_leaf("h", "Hotel"),
-        ]
-    }
-}
+    /// Returns the render height of this item.
+    ///
+    /// This is the height later available at [`render`](Self::render).
+    /// It is used to check which items are visible when the full [`Tree`](crate::Tree) is being rendered.
+    #[must_use]
+    fn height(&self) -> usize;
 
-#[test]
-#[should_panic = "duplicate identifiers"]
-fn tree_item_new_errors_with_duplicate_identifiers() {
-    let item = TreeItem::new_leaf("same", "text");
-    let another = item.clone();
-    TreeItem::new("root", "Root", vec![item, another]).unwrap();
-}
+    /// Returns a reference to the [`Identifier`](Self::Identifier) of the current item.
+    #[must_use]
+    fn identifier(&self) -> &Self::Identifier;
 
-#[test]
-#[should_panic = "identifier already exists"]
-fn tree_item_add_child_errors_with_duplicate_identifiers() {
-    let item = TreeItem::new_leaf("same", "text");
-    let another = item.clone();
-    let mut root = TreeItem::new("root", "Root", vec![item]).unwrap();
-    root.add_child(another).unwrap();
+    /// Render this item to the buffer.
+    ///
+    /// Very similar to [`ratatui::widgets::Widget`] but only takes a reference of `self`.
+    fn render(&self, area: ratatui::layout::Rect, buffer: &mut ratatui::buffer::Buffer);
 }

--- a/src/tree_state.rs
+++ b/src/tree_state.rs
@@ -44,12 +44,6 @@ where
         self.selected.clone()
     }
 
-    /// Get the required height to render all the visible (= below open) [`TreeItem`]s with this `TreeState`.
-    #[must_use]
-    pub fn total_required_height(&self, items: &[TreeItem<'_, Identifier>]) -> usize {
-        crate::flatten::total_required_height(&self.opened, items, &[])
-    }
-
     /// Selects the given identifier.
     ///
     /// Returns `true` when the selection changed.
@@ -68,7 +62,7 @@ where
         changed
     }
 
-    /// Open a tree node.
+    /// Open a tree item.
     /// Returns `true` when it was closed and has been opened.
     /// Returns `false` when it was already open.
     pub fn open(&mut self, identifier: Vec<Identifier>) -> bool {
@@ -79,17 +73,17 @@ where
         }
     }
 
-    /// Close a tree node.
+    /// Close a tree item.
     /// Returns `true` when it was open and has been closed.
     /// Returns `false` when it was already closed.
     pub fn close(&mut self, identifier: &[Identifier]) -> bool {
         self.opened.remove(identifier)
     }
 
-    /// Toggles a tree node open/close state.
-    /// When it is currently open, then [`close`](Self::close) is called. Otherwise [`open`](Self::open).
+    /// Toggles a tree item open/close state.
+    /// When the item is in opened, it calls [`close`](Self::close). Otherwise it calls [`open`](Self::open).
     ///
-    /// Returns `true` when a node is opened / closed.
+    /// Returns `true` when an item is opened / closed.
     /// As toggle always changes something, this only returns `false` when an empty identifier is given.
     pub fn toggle(&mut self, identifier: Vec<Identifier>) -> bool {
         if identifier.is_empty() {
@@ -101,19 +95,19 @@ where
         }
     }
 
-    /// Toggles the currently selected tree node open/close state.
+    /// Toggles the currently selected tree item open/close state.
     /// See also [`toggle`](Self::toggle)
     ///
-    /// Returns `true` when a node is opened / closed.
+    /// Returns `true` when an item is opened / closed.
     /// As toggle always changes something, this only returns `false` when nothing is selected.
     pub fn toggle_selected(&mut self) -> bool {
         self.ensure_selected_in_view_on_next_render = true;
         self.toggle(self.selected())
     }
 
-    /// Closes all open nodes.
+    /// Closes all open items.
     ///
-    /// Returns `true` when any node was closed.
+    /// Returns `true` when any item was closed.
     pub fn close_all(&mut self) -> bool {
         if self.opened.is_empty() {
             false
@@ -123,7 +117,7 @@ where
         }
     }
 
-    /// Select the first node.
+    /// Select the first item.
     ///
     /// Returns `true` when the selection changed.
     pub fn select_first(&mut self) -> bool {
@@ -135,7 +129,7 @@ where
         self.select(identifier)
     }
 
-    /// Select the last visible node.
+    /// Select the last visible item.
     ///
     /// Returns `true` when the selection changed.
     pub fn select_last(&mut self) -> bool {
@@ -147,7 +141,7 @@ where
         self.select(new_identifier)
     }
 
-    /// Select the node visible on the given index.
+    /// Select the item visible on the given index.
     ///
     /// Returns `true` when the selection changed.
     ///
@@ -233,7 +227,7 @@ where
     }
 
     /// Handles the down arrow key.
-    /// Moves down in the current depth or into a child node.
+    /// Moves down in the current depth or into a child item.
     ///
     /// Returns `true` when the selection changed.
     pub fn key_down(&mut self) -> bool {
@@ -267,4 +261,13 @@ where
         self.ensure_selected_in_view_on_next_render = true;
         self.open(self.selected())
     }
+}
+
+/// Get the required height to render all the visible (= below open) [`TreeItem`]s with the given [`TreeState`].
+#[must_use]
+pub fn total_required_height<Item>(state: &TreeState<Item::Identifier>, items: &[Item]) -> usize
+where
+    Item: TreeItem,
+{
+    crate::flatten::total_required_height(&state.opened, items, &[])
 }

--- a/src/unique_identifiers.rs
+++ b/src/unique_identifiers.rs
@@ -1,0 +1,70 @@
+use std::collections::HashSet;
+use std::io::ErrorKind;
+
+use crate::TreeItem;
+
+fn inner<Item>(items: &[Item], error: &'static str) -> std::io::Result<()>
+where
+    Item: TreeItem,
+{
+    let identifiers = items
+        .iter()
+        .map(TreeItem::identifier)
+        .collect::<HashSet<_>>();
+    if identifiers.len() == items.len() {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(ErrorKind::AlreadyExists, error))
+    }
+}
+
+pub(super) fn tree<Item>(items: &[Item]) -> std::io::Result<()>
+where
+    Item: TreeItem,
+{
+    inner(items, "The items contain duplicate identifiers")
+}
+
+/// Ensures that all identifiers in the items are unique.
+///
+/// This is useful when you implement your own [`TreeItem`].
+/// When you mark the calling function with `#[track_caller]` it gets easier to find the misbehaving caller.
+///
+/// # Errors
+///
+/// Errors when there are duplicate identifiers in the children.
+#[track_caller]
+pub fn children<Item>(children: &[Item]) -> std::io::Result<()>
+where
+    Item: TreeItem,
+{
+    inner(children, "The children contain duplicate identifiers")
+}
+
+/// Ensures that the to be added child identifier does not exist in the already existing children.
+///
+/// This is useful when you implement your own [`TreeItem`].
+/// When you mark the calling function with `#[track_caller]` it gets easier to find the misbehaving caller.
+///
+/// # Errors
+///
+/// Errors when the new child would duplicate an existing identifier in the children.
+#[track_caller]
+pub fn add_child<Item>(existing_children: &[Item], add: &Item) -> std::io::Result<()>
+where
+    Item: TreeItem,
+{
+    let add_identifier = add.identifier();
+    let identifier_exists_already = existing_children
+        .iter()
+        .map(Item::identifier)
+        .any(|identifier| identifier == add_identifier);
+    if identifier_exists_already {
+        Err(std::io::Error::new(
+            ErrorKind::AlreadyExists,
+            "The to be added child identifier already exists in the children",
+        ))
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Introduce a `TreeItem` trait which can render itself to the buffer directly when needed. Due to the decoupling of height and render the items in view can be determined without needing to generate the Text for each item upfront. Only the relevant items are rendered then.

This has a huge performance benefit and renders the cargo metadata JSON data in 1/5 of the time. It still takes ~70 ms on a Raspberry Pi 2 to parse the cargo metadata JSON to `JsonTreeItem`s and render them, but it's better than ~320 ms :sparkles:

The current `TreeItem` continues to exist as `PrerenderedTreeItem` but using more efficient `TreeItem` implementations (like the `JsonTreeItem`) will be better especially with many (hidden) items.

---

`cargo bench` output on Raspberry Pi 2:

```plaintext
$ cargo bench
…
    Finished `bench` profile [optimized + debuginfo] target(s) in 20m 38s
…
init/empty              time:   [445.38 ns 445.59 ns 445.83 ns]
                        change: [+0.9440% +1.0696% +1.1920%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 18 outliers among 100 measurements (18.00%)
  5 (5.00%) high mild
  13 (13.00%) high severe
init/example-items      time:   [20.460 µs 20.463 µs 20.465 µs]
                        change: [-67.323% -67.288% -67.262%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
Benchmarking init/metadata: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.0s, or reduce sample count to 90.
init/metadata           time:   [49.955 ms 50.056 ms 50.114 ms]
                        change: [-77.299% -77.247% -77.210%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild
  4 (4.00%) high severe

render/empty            time:   [231.75 µs 231.81 µs 231.87 µs]
                        change: [-5.8634% -5.1479% -4.3294%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
render/example-items    time:   [328.60 µs 328.73 µs 328.87 µs]
                        change: [-7.7537% -6.4460% -5.4807%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe
render/metadata         time:   [19.944 ms 19.957 ms 19.969 ms]
                        change: [-79.122% -79.080% -79.036%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild
  2 (2.00%) high severe
```