### PR TITLE
feat(state): click_at

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crossterm::event::{Event, KeyCode, MouseEventKind};
 use ratatui::backend::{Backend, CrosstermBackend};
-use ratatui::layout::Rect;
+use ratatui::layout::{Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use ratatui::widgets::{Block, Scrollbar, ScrollbarOrientation};
@@ -166,6 +166,9 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::io::Res
                 Event::Mouse(mouse) => match mouse.kind {
                     MouseEventKind::ScrollDown => app.state.scroll_down(1),
                     MouseEventKind::ScrollUp => app.state.scroll_up(1),
+                    MouseEventKind::Down(_button) => {
+                        app.state.click_at(Position::new(mouse.column, mouse.row))
+                    }
                     _ => false,
                 },
                 Event::Resize(_, _) => true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ where
                 buf.set_style(area, self.highlight_style);
             }
         }
-        state.last_visible_identifiers = visible
+        state.last_identifiers = visible
             .into_iter()
             .map(|flattened| flattened.identifier)
             .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,8 @@ where
             inner_area
         });
 
+        state.last_area = area;
+        state.last_rendered_identifiers.clear();
         if area.width < 1 || area.height < 1 {
             return;
         }
@@ -324,6 +326,10 @@ where
             if is_selected {
                 buf.set_style(area, self.highlight_style);
             }
+
+            state
+                .last_rendered_identifiers
+                .push((area.y, identifier.clone()));
         }
         state.last_identifiers = visible
             .into_iter()

--- a/src/tree_state.rs
+++ b/src/tree_state.rs
@@ -178,7 +178,7 @@ where
     /// Returns `true` when the selection changed.
     ///
     /// This can be useful for mouse clicks.
-    #[deprecated = "Prefer self.select_at, self.click_at or self.rendered_at as visible index is hard to predict with height != 1"]
+    #[deprecated = "Prefer self.click_at or self.rendered_at as visible index is hard to predict with height != 1"]
     pub fn select_visible_index(&mut self, new_index: usize) -> bool {
         let new_index = new_index.min(self.last_biggest_index);
         let new_identifier = self

--- a/src/tree_state.rs
+++ b/src/tree_state.rs
@@ -258,22 +258,6 @@ where
         self.select(new_identifier)
     }
 
-    /// Select the node that was rendered for the given position on last render.
-    ///
-    /// Returns `true` when the selection changed.
-    #[must_use]
-    pub fn select_at(&mut self, position: Position) -> bool {
-        if let Some(identifier) = self.rendered_at(position) {
-            if identifier == self.selected {
-                false
-            } else {
-                self.select(identifier.to_vec())
-            }
-        } else {
-            false
-        }
-    }
-
     /// Get the identifier that was rendered for the given position on last render.
     #[must_use]
     pub fn rendered_at(&self, position: Position) -> Option<&[Identifier]> {

--- a/src/tree_state.rs
+++ b/src/tree_state.rs
@@ -281,14 +281,11 @@ where
             return None;
         }
 
-        let at_position = self
-            .last_rendered_identifiers
+        self.last_rendered_identifiers
             .iter()
             .rev()
             .find(|(y, _)| position.y >= *y)
-            .map(|(_, identifier)| identifier.as_ref());
-
-        at_position
+            .map(|(_, identifier)| identifier.as_ref())
     }
 
     /// Select what was rendered at the given position on last render.


### PR DESCRIPTION
Allows clicking at a given position.

Stores the last area and the y position where items are rendered to determine which identifier was clicked. When it was already selected, toggle it's open/close state.