### PR TITLE
feat(tree_item): add method to expose `identifier`

### DIFF
--- a/src/tree_item.rs
+++ b/src/tree_item.rs
@@ -84,6 +84,11 @@ where
         })
     }
 
+    /// Get a reference to the identifier.
+    pub const fn identifier(&self) -> &Identifier {
+        &self.identifier
+    }
+
     #[must_use]
     pub fn children(&self) -> &[Self] {
         &self.children

--- a/src/tree_item.rs
+++ b/src/tree_item.rs
@@ -85,6 +85,7 @@ where
     }
 
     /// Get a reference to the identifier.
+    #[must_use]
     pub const fn identifier(&self) -> &Identifier {
         &self.identifier
     }


### PR DESCRIPTION
Resolve #37

Add the `TreeItem::identifier` method to get a reference to the `TreeItem` identifier.