### PR TITLE
Fixing double key press issue on windows + crossterm

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -150,7 +150,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::io::Res
         let timeout = debounce.map_or(DEBOUNCE, |start| DEBOUNCE.saturating_sub(start.elapsed()));
         if crossterm::event::poll(timeout)? {
             let update = match crossterm::event::read()? {
-                Event::Key(key) => match key.code {
+                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         return Ok(())
                     }


### PR DESCRIPTION
On windows, when using Crossterm, both Press and Release events being fired and therefore action associated with all keyboard events executed twice. This is visually observed especially Up and Down events.