### PR TITLE
docs(example): only handle key press and not release events

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use ratatui::backend::{Backend, CrosstermBackend};
-use ratatui::crossterm::event::{Event, KeyCode, KeyModifiers, MouseEventKind};
+use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
 use ratatui::layout::{Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
@@ -150,7 +150,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::io::Res
         let timeout = debounce.map_or(DEBOUNCE, |start| DEBOUNCE.saturating_sub(start.elapsed()));
         if crossterm::event::poll(timeout)? {
             let update = match crossterm::event::read()? {
-                Event::Key(key) => match key.code {
+                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         return Ok(())
                     }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -150,7 +150,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::io::Res
         let timeout = debounce.map_or(DEBOUNCE, |start| DEBOUNCE.saturating_sub(start.elapsed()));
         if crossterm::event::poll(timeout)? {
             let update = match crossterm::event::read()? {
-                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
+                Event::Key(key) if !matches!(key.kind, KeyEventKind::Press) => false,
+                Event::Key(key) => match key.code {
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         return Ok(())
                     }


### PR DESCRIPTION
on windows using crossterm backend, each key press fires press and release events and therefore, the function associated with each key is called twice. This fixes that.