### PR TITLE
feat(tree_item): add method to expose text

### DIFF
--- a/src/tree_item.rs
+++ b/src/tree_item.rs
@@ -90,6 +90,12 @@ where
         &self.identifier
     }
 
+    /// Get a reference to the text.
+    #[must_use]
+    pub const fn text(&self) -> &Text<'text> {
+        &self.text
+    }
+
     #[allow(clippy::missing_const_for_fn)] // False positive
     #[must_use]
     pub fn children(&self) -> &[Self] {


### PR DESCRIPTION
Hi! I want to use `text` field in `TreeItem`, can you merge this PR ?